### PR TITLE
fix: list_restore_filedescriptor leaks and list_dump_filedescriptor bug

### DIFF
--- a/simclist.c
+++ b/simclist.c
@@ -1187,6 +1187,10 @@ int list_dump_filedescriptor(const list_t *restrict l, int fd, size_t *restrict 
                         header.elemlen = 0;
                         header.totlistlen = 0;
                         x = l->head_sentinel;
+                        if (lseek(fd, SIMCLIST_DUMPFORMAT_HEADERLEN, SEEK_SET) < 0) {
+                            /* errno set by lseek() */
+                            return -1;
+                        }
                         /* restart from the beginning */
                         continue;
                     }

--- a/simclist.c
+++ b/simclist.c
@@ -1292,6 +1292,8 @@ int list_restore_filedescriptor(list_t *restrict l, int fd, size_t *restrict len
                 buf = malloc(header.elemlen);
                 READ_ERRCHECK(fd, buf, header.elemlen);
                 list_append(l, buf);
+                if (l->attrs.copy_data)
+                    free(buf);
             }
             totmemorylen = header.numels * header.elemlen;
         }
@@ -1316,6 +1318,8 @@ int list_restore_filedescriptor(list_t *restrict l, int fd, size_t *restrict len
                 READ_ERRCHECK(fd, buf, elsize);
                 totreadlen += elsize;
                 list_append(l, buf);
+                if (l->attrs.copy_data)
+                    free(buf);
             }
             totmemorylen = totreadlen;
         }


### PR DESCRIPTION
… file has attribute copy_data set

Paste the following commands into a linux console to test (I'm using ubuntu 21) and replicate the error:

```
git clone https://github.com/mij/simclist && \
cd simclist && \
sed -i 's/-O2 -Wall/-O0 -g -Wall/g' CMakeLists.txt
mkdir build & \&
cd build && \
cmake .. && \
make VERBOSE=1
```

```
cat << EOF > test_simclist_dump_restore.c
#include <stdio.h>
#include <stdlib.h>
#include "../simclist.h"

struct my_type {
    uint32_t a;
    uint32_t b;
};

static size_t _my_size(const void *el) {
  return sizeof(struct my_type);
}

void save_and_restore_list()
{
    list_t list;
    list_init(&list);
    list_attributes_copy(&list, _my_size, 1);

    // add some data
    for (int32_t i=0; i<1000; i++) {
    	struct my_type t;
    	t.a=i;
    	t.b=i;
        list_append(&list, &t);
    }

    int err = list_dump_file(&list, "dumpedlist", NULL);
    list_destroy(&list);
    if (err) {
        printf("failed to dump the list\n");
        return;
    }

    list_t restored_list;
    list_init(&restored_list);
    list_attributes_copy(&restored_list, _my_size, 1);
    err = list_restore_file(&restored_list, "dumpedlist", NULL);
    if (err) {
        printf("failed to restore the list\n");    
        return;
    }
    struct my_type* t = (struct my_type*)list_get_at(&restored_list, 0);
    printf("get i from restore list %u\n", t->a);
    list_destroy(&restored_list);
}

int main()
{
    save_and_restore_list();
    save_and_restore_list();
    return 0;
}
EOF

gcc test_simclist_dump_restore.c -g -O0 -Wall -Werror -o testdumprestore -L. -lsimclist && \
LD_LIBRARY_PATH=. valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes ./testdumprestore

```