### PR TITLE
Fix size mismatch in list_dump_filedescriptor

### DIFF
--- a/simclist.c
+++ b/simclist.c
@@ -1176,7 +1176,7 @@ int list_dump_filedescriptor(const list_t *restrict l, int fd, size_t *restrict 
                     /* speculation confirmed */
                     WRITE_ERRCHECK(fd, ser_buf, bufsize);
                 } else {                        /* speculation found broken */
-                    WRITE_ERRCHECK(fd, & bufsize, sizeof(size_t));
+                    WRITE_ERRCHECK(fd, & bufsize, sizeof(bufsize));
                     WRITE_ERRCHECK(fd, ser_buf, bufsize);
                 }
                 free(ser_buf);
@@ -1203,7 +1203,7 @@ int list_dump_filedescriptor(const list_t *restrict l, int fd, size_t *restrict 
                     }
                     WRITE_ERRCHECK(fd, x->data, bufsize);
                 } else {
-                    WRITE_ERRCHECK(fd, &bufsize, sizeof(size_t));
+                    WRITE_ERRCHECK(fd, &bufsize, sizeof(bufsize));
                     WRITE_ERRCHECK(fd, x->data, bufsize);
                 }
             }


### PR DESCRIPTION
Fixed compilation error. But the error is valid.

```sh
tools/simclist.c: In function ‘list_dump_filedescriptor’:
tools/simclist.c:174:57: error: ‘write’ reading 8 bytes from a region of size 4 [-Werror=stringop-overread]
  174 |                                                     if (write(fd, msgbuf, msglen) < 0) return -1;       \
      |                                                         ^~~~~~~~~~~~~~~~~~~~~~~~~
tools/simclist.c:1087:21: note: in expansion of macro ‘WRITE_ERRCHECK’
 1087 |                     WRITE_ERRCHECK(fd, & bufsize, sizeof(size_t));
      |                     ^~~~~~~~~~~~~~
tools/simclist.c:1001:14: note: source object ‘bufsize’ of size 4
 1001 |     uint32_t bufsize;
      |              ^~~~~~~
In file included from tools/simclist.c:32:
/usr/include/unistd.h:378:16: note: in a call to function ‘write’ declared with attribute ‘access (read_only, 2, 3)’
  378 | extern ssize_t write (int __fd, const void *__buf, size_t __n) __wur
      |                ^~~~~
tools/simclist.c:174:57: error: ‘write’ reading 8 bytes from a region of size 4 [-Werror=stringop-overread]
  174 |                                                     if (write(fd, msgbuf, msglen) < 0) return -1;       \
      |                                                         ^~~~~~~~~~~~~~~~~~~~~~~~~
tools/simclist.c:1110:21: note: in expansion of macro ‘WRITE_ERRCHECK’
 1110 |                     WRITE_ERRCHECK(fd, &bufsize, sizeof(size_t));
      |                     ^~~~~~~~~~~~~~
```

Remark: this was on an older version included in one of my home projects. So I stepped up the version and fixed the error. 