### PR TITLE
Reset mid field when the list is empty to avoid assert() errors

### DIFF
--- a/simclist.c
+++ b/simclist.c
@@ -472,6 +472,9 @@ void *list_extract_at(list_t *restrict l, unsigned int pos) {
     list_drop_elem(l, tmp, pos);
     l->numels--;
 
+    if (0 == l->numels)
+        l->mid = NULL;
+
     assert(list_repOk(l));
 
     return data;
@@ -555,6 +558,8 @@ int list_delete_at(list_t *restrict l, unsigned int pos) {
 
     l->numels--;
 
+    if (0 == l->numels)
+        l->mid = NULL;
 
     assert(list_repOk(l));
 


### PR DESCRIPTION
Patch from https://github.com/LudovicRousseau/PCSC/commit/8999ddfc04ecbf596af1eea6efb6ed3c49392089

I am not sure this patch is still needed.
I patched the code in 2010 and I do not remember what was the effects of the unpatched code. Sorry.