### PR TITLE
Guard NDEBUG behind an ifdef

### DIFF
--- a/simclist.c
+++ b/simclist.c
@@ -44,7 +44,9 @@
 
 /* disable asserts */
 #ifndef SIMCLIST_DEBUG
+#ifndef NDEBUG
 #define NDEBUG
+#endif
 #endif
 
 #include <assert.h>


### PR DESCRIPTION
Needed for Android as NDEBUG is already defined.

Patch from https://github.com/LudovicRousseau/PCSC/commit/285007c02dfac88cbabf2b056aa181190c4324d1